### PR TITLE
build: produce commonjs modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/monaco-logql",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "LogQL support for Monaco code editor",
   "main": "index.js",
   "scripts": {

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-		"module": "esnext",
+		"module": "commonjs",
 		"moduleResolution": "node",
 		"outDir": "../dist",
 		"target": "es5",


### PR DESCRIPTION
the generated javascript file (`dist/index.js`) should be in "commonjs" format, (the module-system used by nodejs, things like `exports.foo = ...`, otherwise, when using this module, `jest` complains.

(we could probably do some cooler things here, building both `commonjs` and `modern js` versions of the files and adjusting `package.json` accordingly, but for now i just want to make things work 😄 )