### PR TITLE
improve time duration regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "monaco-logql",
-  "version": "0.0.2",
+  "name": "@grafana/monaco-logql",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "monaco-logql",
-      "version": "0.0.2",
-      "license": "ISC",
+      "name": "@grafana/monaco-logql",
+      "version": "0.0.7",
+      "license": "Apache-2.0",
       "devDependencies": {
         "monaco-editor": "^0.32.1",
         "typescript": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/monaco-logql",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "LogQL support for Monaco code editor",
   "main": "index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ export const monarchlanguage: languages.IMonarchLanguage = {
       ],
 
       // numbers
-      [/\d+[smhdwy]/, "number"], // 24h, 5m are often encountered in loki
+      [/\d+(?:ms|[smhdwy])/, "number"], // 24h, 5ms are often encountered in loki
       [/\d*\d+[eE]([\-+]?\d+)?(@floatsuffix)/, "number.float"],
       [/\d*\.\d+([eE][\-+]?\d+)?(@floatsuffix)/, "number.float"],
       [/0[xX][0-9a-fA-F']*[0-9a-fA-F](@integersuffix)/, "number.hex"],


### PR DESCRIPTION
Based on https://prometheus.io/docs/prometheus/latest/querying/basics/#time-durations we can also have `ms` as a duration. The current regex does not fit this, as seen in this image:

<img width="156" alt="image" src="https://user-images.githubusercontent.com/8092184/220770453-0459dff6-de7a-4fff-9d31-52919d681589.png">

The new regex looks like it fits well: https://regex101.com/r/VAEudi/1