### PR TITLE
chore: auto-audit hygiene fixes

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,7 +15,7 @@ jobs:
           ref: main
       # limit releases to version changes - https://github.com/EndBug/version-check
       - name: Check version changes
-        uses: EndBug/version-check@v1
+        uses: EndBug/version-check@eea9dab124be9214bd32356f32f7d8945173db13 # v1
         id: version_check
         with:
           # diff the commits rather than commit message for version changes

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+ignore-scripts=true
+allow-git=none
+min-release-age=3
+registry=https://registry.npmjs.org/
+save-exact=true
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,10 @@
         "monaco-editor": "^0.32.1",
         "typescript": "^4.2.3"
       },
+      "engines": {
+        "node": ">=24",
+        "npm": ">=11.15.0"
+      },
       "peerDependencies": {
         "monaco-editor": "^0.32.1"
       }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,9 @@
   "bugs": {
     "url": "https://github.com/grafana/monaco-logql/issues"
   },
-  "homepage": "https://github.com/grafana/monaco-logql#readme"
+  "homepage": "https://github.com/grafana/monaco-logql#readme",
+  "engines": {
+    "node": ">=24",
+    "npm": ">=11.15.0"
+  }
 }


### PR DESCRIPTION
Automated repo hygiene audit. This branch applies the following standard changes:

- Set `engines` in `package.json` to `node >=24` (and `npm >=11.15.0` for npm-based repos), across every `package.json` outside `node_modules`.
- Replace `.npmrc` with the standard supply-chain-hardened template (`ignore-scripts`, `allow-git=none`, `min-release-age=3`, `engine-strict`).

### Notes

- All commits are SSH-signed.
- Audit was applied uniformly across ~70 Grafana data-source / library repos. See [the audit driver](https://github.com/grafana/) (run locally) for the full ruleset.
- Please skim the diff before merging.