### PR TITLE
chore(deps): use type-only import for monaco deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/monaco-logql",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/monaco-logql",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "monaco-editor": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/monaco-logql",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "LogQL support for Monaco code editor",
   "main": "index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { languages } from "monaco-editor";
+import type { languages } from "monaco-editor";
 
 export const languageConfiguration: languages.LanguageConfiguration = {
   // the default separators except `@$`


### PR DESCRIPTION
This PR updates the language definition to use a type-only import. 